### PR TITLE
Spoof origin for Node requests

### DIFF
--- a/src/bridge/http.js
+++ b/src/bridge/http.js
@@ -15,8 +15,11 @@ let _fetch: (input: string | Request, init?: RequestOptions) => Promise<Response
     ? () => Promise.reject()
     : window.fetch;
 
-export function setFetch(fetch: any) {
+let _isNode = false;
+
+export function setFetch(fetch: any, isNode?: boolean) {
   _fetch = fetch;
+  _isNode = !!isNode;
 }
 
 function contentType(body: any): string {
@@ -51,17 +54,25 @@ export async function request(options: HttpRequestOptions): Promise<mixed> {
     method: options.method,
     body: wrapBody(options.body),
     credentials: `same-origin`,
+    headers: {}
   };
 
   // this is just for flowtype
   if (options.skipContentTypeHeader == null || options.skipContentTypeHeader === false) {
-    fetchOptions = {
-      ...fetchOptions,
-      headers: {
-        'Content-Type': contentType(options.body == null ? `` : options.body),
-      },
+    fetchOptions.headers = {
+      ...fetchOptions.headers,
+      'Content-Type': contentType(options.body == null ? `` : options.body),
     };
   }
+
+  // Node applications must spoof origin for bridge CORS
+  if (_isNode) {
+    fetchOptions.headers = {
+      ...fetchOptions.headers,
+      'Origin': 'https://node.trezor.io',
+    };
+  }
+
   const res = await _fetch(options.url, fetchOptions);
   const resText = await res.text();
   if (res.ok) {

--- a/src/bridge/http.js
+++ b/src/bridge/http.js
@@ -50,11 +50,11 @@ function parseResult(text: string): mixed {
 }
 
 export async function request(options: HttpRequestOptions): Promise<mixed> {
-  let fetchOptions = {
+  const fetchOptions = {
     method: options.method,
     body: wrapBody(options.body),
     credentials: `same-origin`,
-    headers: {}
+    headers: {},
   };
 
   // this is just for flowtype
@@ -69,7 +69,7 @@ export async function request(options: HttpRequestOptions): Promise<mixed> {
   if (_isNode) {
     fetchOptions.headers = {
       ...fetchOptions.headers,
-      'Origin': 'https://node.trezor.io',
+      'Origin': `https://node.trezor.io`,
     };
   }
 

--- a/src/bridge/v1.js
+++ b/src/bridge/v1.js
@@ -145,8 +145,8 @@ export default class BridgeTransport {
     return check.call(res);
   }
 
-  static setFetch(fetch: any) {
-    rSetFetch(fetch);
+  static setFetch(fetch: any, isNode?: boolean) {
+    rSetFetch(fetch, isNode);
   }
 
   requestDevice(): Promise<void> {

--- a/src/bridge/v2.js
+++ b/src/bridge/v2.js
@@ -142,8 +142,8 @@ export default class BridgeTransport {
     return check.call(jsonData);
   }
 
-  static setFetch(fetch: any) {
-    rSetFetch(fetch);
+  static setFetch(fetch: any, isNode?: boolean) {
+    rSetFetch(fetch, isNode);
   }
 
   requestDevice(): Promise<void> {

--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,11 @@ import 'whatwg-fetch';
 if (typeof window === `undefined`) {
   // eslint-disable-next-line quotes
   const fetch = require('node-fetch');
-  BridgeTransportV1.setFetch(fetch);
-  BridgeTransportV2.setFetch(fetch);
+  BridgeTransportV1.setFetch(fetch, true);
+  BridgeTransportV2.setFetch(fetch, true);
 } else {
-  BridgeTransportV1.setFetch(fetch);
-  BridgeTransportV2.setFetch(fetch);
+  BridgeTransportV1.setFetch(fetch, false);
+  BridgeTransportV2.setFetch(fetch, false);
 }
 
 export default {


### PR DESCRIPTION
This is in lieu of https://github.com/trezor/trezord-go/pull/69, sets an origin of `https://node.trezor.io` to get past trezord's CORS check.

While I was able to test the gist of this change by manually editing the code in my node_modules folder, I was unable to get a build to work due to the make file trying to copy symlinks, which it didn't like (`cp: src//flow_fake_node_modules/node-hid: No such file or directory`.)