### PR TITLE
Accept bridge newest version as data

### DIFF
--- a/src/bridge/v2.js
+++ b/src/bridge/v2.js
@@ -33,7 +33,7 @@ export default class BridgeTransport {
 
   url: string;
   newestVersionUrl: string;
-  newVersion: string;
+  newVersion: ?string;
   debug: boolean = false;
 
   configured: boolean = false;
@@ -41,7 +41,7 @@ export default class BridgeTransport {
 
   stopped: boolean = false;
 
-  constructor(url?: ?string, newestVersionUrl?: ?string, newVersion?: string) {
+  constructor(url?: ?string, newestVersionUrl?: ?string, newVersion?: ?string) {
     this.url = url == null ? DEFAULT_URL : url;
     this.newestVersionUrl = newestVersionUrl == null ? DEFAULT_VERSION_URL : newestVersionUrl;
     this.newVersion = newVersion;

--- a/src/bridge/v2.js
+++ b/src/bridge/v2.js
@@ -33,6 +33,7 @@ export default class BridgeTransport {
 
   url: string;
   newestVersionUrl: string;
+  newVersion: string;
   debug: boolean = false;
 
   configured: boolean = false;
@@ -40,9 +41,10 @@ export default class BridgeTransport {
 
   stopped: boolean = false;
 
-  constructor(url?: ?string, newestVersionUrl?: ?string) {
+  constructor(url?: ?string, newestVersionUrl?: ?string, newVersion?: string) {
     this.url = url == null ? DEFAULT_URL : url;
     this.newestVersionUrl = newestVersionUrl == null ? DEFAULT_VERSION_URL : newestVersionUrl;
+    this.newVersion = newVersion;
   }
 
   async _post(options: IncompleteRequestOptions): Promise<mixed> {
@@ -65,7 +67,7 @@ export default class BridgeTransport {
     });
     const info = check.info(infoS);
     this.version = info.version;
-    const newVersion = check.version(await http({
+    const newVersion = typeof this.newVersion === `string` ? this.newVersion : check.version(await http({
       url: `${this.newestVersionUrl}?${Date.now()}`,
       method: `GET`,
     }));


### PR DESCRIPTION
This PR optionally allows to send latest bridge version as data (string) to avoid fetching those data from "latest.txt" file