### PR TITLE
Remove device.reset() from WebUSB plugin

### DIFF
--- a/src/lowlevel/webusb.js
+++ b/src/lowlevel/webusb.js
@@ -182,6 +182,13 @@ export default class WebUsbPlugin {
 
     if (first) {
       await device.selectConfiguration(this.configurationId);
+
+      if (typeof navigator !== `undefined`) {
+        const chromeOS = /\bCrOS\b/.test(navigator.userAgent);
+        if (!chromeOS) {
+          await device.reset();
+        }
+      }
     }
 
     const interfaceId = debug ? this.debugInterfaceId : this.normalInterfaceId;

--- a/src/lowlevel/webusb.js
+++ b/src/lowlevel/webusb.js
@@ -182,7 +182,6 @@ export default class WebUsbPlugin {
 
     if (first) {
       await device.selectConfiguration(this.configurationId);
-      await device.reset();
     }
 
     const interfaceId = debug ? this.debugInterfaceId : this.normalInterfaceId;


### PR DESCRIPTION
ChromeOS is unable to reset the device for (currently) unknown reason. But it seems that device reset is not even needed. It has to be tested thoroughly though. 